### PR TITLE
[FEAT] 유저의 정보 저장

### DIFF
--- a/src/main/java/com/zerorealup/codefit/core/config/WebConfig.java
+++ b/src/main/java/com/zerorealup/codefit/core/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.zerorealup.codefit.core.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/zerorealup/codefit/feedback/domain/Feedback.java
+++ b/src/main/java/com/zerorealup/codefit/feedback/domain/Feedback.java
@@ -29,7 +29,7 @@ public class Feedback extends BaseTimeEntity {
     private String difficulty;
 
     @Lob
-    @Column(name = "feedback_result", nullable = false)
+    @Column(name = "feedback_result", columnDefinition = "TEXT", nullable = false)
     private String feedbackResult;
 
     public static Feedback createFeedback(Long memberId, String problemTitle, String difficulty, String feedbackResult) {

--- a/src/main/java/com/zerorealup/codefit/member/api/MemberController.java
+++ b/src/main/java/com/zerorealup/codefit/member/api/MemberController.java
@@ -1,0 +1,23 @@
+package com.zerorealup.codefit.member.api;
+
+import com.zerorealup.codefit.member.api.dto.OnboardingRequest;
+import com.zerorealup.codefit.member.domain.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+    private final MemberService memberService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/{memberId}/onboarding")
+    public void saveOnboarding(
+            @PathVariable Long memberId,
+            @RequestBody OnboardingRequest request
+    ) {
+        memberService.updateOnboarding(memberId, request);
+    }
+}

--- a/src/main/java/com/zerorealup/codefit/member/api/dto/OnboardingRequest.java
+++ b/src/main/java/com/zerorealup/codefit/member/api/dto/OnboardingRequest.java
@@ -1,0 +1,34 @@
+package com.zerorealup.codefit.member.api.dto;
+
+
+import com.zerorealup.codefit.member.domain.enums.Level;
+import com.zerorealup.codefit.member.domain.enums.ProblemCategory;
+
+import java.util.Set;
+
+public record OnboardingRequest(
+        String       level,       // 한글: 입문, 중급, 상급
+        String       dailyCount,  // 문자열로 수신 → int 변환
+        Set<String>  mostSolved,  // 영문 카테고리
+        Set<String>  hardest      // 영문 카테고리
+) {
+    public Level levelEnum() {
+        return Level.from(level);
+    }
+
+    public int dailyCountValue() {
+        return Integer.parseInt(dailyCount);
+    }
+
+    public Set<ProblemCategory> mostSolvedSet() {
+        return mostSolved.stream()
+                .map(ProblemCategory::from)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    public Set<ProblemCategory> hardestSet() {
+        return hardest.stream()
+                .map(ProblemCategory::from)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+}

--- a/src/main/java/com/zerorealup/codefit/member/domain/Member.java
+++ b/src/main/java/com/zerorealup/codefit/member/domain/Member.java
@@ -1,23 +1,27 @@
 package com.zerorealup.codefit.member.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.zerorealup.codefit.member.domain.enums.Level;
+import com.zerorealup.codefit.member.domain.enums.ProblemCategory;
+import jakarta.persistence.*;
+import lombok.*;
 
-import lombok.Getter;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * 이 클래스는 멤버의 엔티티를 담당합니다.
  */
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "members")
 public class Member {
-
     /** 유저 아이디 */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Long id;
 
     /** 하루 목표 */
     @Column(name = "goal", nullable = false)
@@ -34,4 +38,43 @@ public class Member {
     /** 알림을 받을 이메일 */
     @Column(name = "email", nullable = false)
     private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "level")
+    private Level level;
+
+    @Column(name = "daily_count")
+    private Integer dailyCount;
+
+    /* 가장 많이 푼 유형 */
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "member_most_solved",
+            joinColumns = @JoinColumn(name = "member_id")
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private Set<ProblemCategory> mostSolved = new LinkedHashSet<>();
+
+    /* 가장 어려웠던 유형 */
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "member_hardest",
+            joinColumns = @JoinColumn(name = "member_id")
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private Set<ProblemCategory> hardest = new LinkedHashSet<>();
+
+    public void updateOnboarding(
+            Level level, int dailyCount,
+            Set<ProblemCategory> mostSolved, Set<ProblemCategory> hardest
+    ) {
+        this.level = level;
+        this.dailyCount = dailyCount;
+        this.mostSolved.clear();
+        this.mostSolved.addAll(mostSolved);
+        this.hardest.clear();
+        this.hardest.addAll(hardest);
+    }
 }

--- a/src/main/java/com/zerorealup/codefit/member/domain/enums/Level.java
+++ b/src/main/java/com/zerorealup/codefit/member/domain/enums/Level.java
@@ -1,0 +1,14 @@
+package com.zerorealup.codefit.member.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Level {
+    입문,
+    중급,
+    상급;
+
+    public static Level from(String value) {
+        return Level.valueOf(value);
+    }
+}

--- a/src/main/java/com/zerorealup/codefit/member/domain/enums/ProblemCategory.java
+++ b/src/main/java/com/zerorealup/codefit/member/domain/enums/ProblemCategory.java
@@ -1,0 +1,19 @@
+package com.zerorealup.codefit.member.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ProblemCategory {
+    MATH,
+    IMPLEMENTATION,
+    GREEDY,
+    STRING,
+    DATA_STRUCTURES,
+    GRAPHS,
+    DP,
+    GEOMETRY;
+
+    public static ProblemCategory from(String value) {
+        return ProblemCategory.valueOf(value.toUpperCase());
+    }
+}

--- a/src/main/java/com/zerorealup/codefit/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/zerorealup/codefit/member/domain/repository/MemberRepository.java
@@ -1,7 +1,7 @@
 package com.zerorealup.codefit.member.domain.repository;
 
 import com.zerorealup.codefit.member.domain.Member;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * 이 클래스는 멤버 리포지토리를 담당합니다.

--- a/src/main/java/com/zerorealup/codefit/member/domain/repository/ProblemHistoryRepository.java
+++ b/src/main/java/com/zerorealup/codefit/member/domain/repository/ProblemHistoryRepository.java
@@ -13,5 +13,5 @@ import org.springframework.stereotype.Repository;
 public interface ProblemHistoryRepository extends JpaRepository<ProblemHistory, Long> {
 
 	@Query("SELECT p.problemId FROM ProblemHistory p WHERE p.member.id = :memberId")
-	List<Integer> findAllByMemberId(int memberId);
+	List<Integer> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/zerorealup/codefit/member/domain/service/MemberService.java
+++ b/src/main/java/com/zerorealup/codefit/member/domain/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.zerorealup.codefit.member.domain.service;
 
+import com.zerorealup.codefit.member.api.dto.OnboardingRequest;
 import com.zerorealup.codefit.member.common.exception.NotFoundMemberException;
 import com.zerorealup.codefit.member.domain.Member;
 import com.zerorealup.codefit.member.domain.repository.MemberRepository;
@@ -16,5 +17,16 @@ public class MemberService {
     public Member findExistingMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundMemberException(memberId));
+    }
+
+    @Transactional
+    public void updateOnboarding(Long memberId, OnboardingRequest req) {
+        Member member = findExistingMember(memberId);
+        member.updateOnboarding(
+                req.levelEnum(),
+                req.dailyCountValue(),
+                req.mostSolvedSet(),
+                req.hardestSet()
+        );
     }
 }


### PR DESCRIPTION
## Issue Number
#14 

## As-Is
<!-- 문제 상황 정의 -->
온보딩 페이지에서 유저의 정보를 입력 받아 저장

## To-Be
<!-- 변경 사항 -->
- [x] 유저의 정보(하루에 풀 문제의 수, github, 백준 아이디, 알림받을 이메일)등을 입력 받아 DB에 저장한다.
- [x] 정보에 대해 유효성 검증을 한다.

## ✅ Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## 📸 Test Screenshot

## Additional Description
